### PR TITLE
fix:read_next_message() when recv chinese

### DIFF
--- a/websocket_server/websocket_server.py
+++ b/websocket_server/websocket_server.py
@@ -233,11 +233,11 @@ class WebSocketHandler(StreamRequestHandler):
             payload_length = struct.unpack(">Q", self.rfile.read(8))[0]
 
         masks = self.read_bytes(4)
-        decoded = ""
-        for char in self.read_bytes(payload_length):
-            char ^= masks[len(decoded) % 4]
-            decoded += chr(char)
-        opcode_handler(self, decoded)
+        message_bytes = bytearray()
+        for message_byte in self.read_bytes(payload_length):
+            message_byte ^= masks[len(message_bytes) % 4]
+            message_bytes.append(message_byte)
+        opcode_handler(self, message_bytes.decode('utf8'))
 
     def send_message(self, message):
         self.send_text(message)


### PR DESCRIPTION
we can't decode message form payload byte by byte. some payload like Chinese word encode by utf-8 need 3 bytes to 	
indicate one char. so, collect all bytes from payload and decode them in one times may be better.